### PR TITLE
Support Swift 5 with Xcode 10.2.1

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "BrightFutures",
-        "repositoryURL": "https://github.com/slessans/BrightFutures",
+        "repositoryURL": "https://github.com/Thomvis/BrightFutures",
         "state": {
-          "branch": "bug-swift5pm",
-          "revision": "46b18f423ea3969569d428a48f40f47a5b021504",
-          "version": null
+          "branch": null,
+          "revision": "9279defa6bdc21501ce740266e5a14d0119ddc63",
+          "version": "8.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/Quick/Nimble.git",
         "state": {
           "branch": null,
-          "revision": "e9d769113660769a4d9dd3afb855562c0b7ae7b0",
-          "version": "7.3.4"
+          "revision": "f8657642dfdec9973efc79cc68bcef43a653a2bc",
+          "version": "8.0.2"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/Quick/Quick.git",
         "state": {
           "branch": null,
-          "revision": "f2b5a06440ea87eba1a167cab37bf6496646c52e",
-          "version": "1.3.4"
+          "revision": "94df9b449508344667e5afc7e80f8bcbff1e4c37",
+          "version": "2.1.0"
         }
       },
       {
@@ -42,17 +42,8 @@
         "repositoryURL": "https://github.com/ReactiveCocoa/ReactiveSwift",
         "state": {
           "branch": null,
-          "revision": "4f6a12ae6762e825b0e19a4f7076eafa43847e6e",
-          "version": "4.0.0"
-        }
-      },
-      {
-        "package": "Result",
-        "repositoryURL": "https://github.com/antitypical/Result.git",
-        "state": {
-          "branch": null,
-          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
-          "version": "4.1.0"
+          "revision": "b772fa0b624926e6e2f21acbb79297736a05c585",
+          "version": "6.1.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "BrightFutures",
-        "repositoryURL": "https://github.com/Thomvis/BrightFutures",
+        "repositoryURL": "https://github.com/slessans/BrightFutures",
         "state": {
-          "branch": null,
-          "revision": "b86a1d202afff7bfca7adf2423ad1962172ee10a",
-          "version": "7.0.0"
+          "branch": "bug-swift5pm",
+          "revision": "46b18f423ea3969569d428a48f40f47a5b021504",
+          "version": null
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/kareman/FootlessParser",
         "state": {
           "branch": null,
-          "revision": "0727844a06fd62e3fe0289e97078476e97d515cf",
-          "version": "0.5.1"
+          "revision": "11c7a366720a2cc62d13ee69c8bdb8372bb3bb2b",
+          "version": "0.5.2"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -10,9 +10,9 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/kareman/FootlessParser", .upToNextMajor(from:"0.5.1")),
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", .upToNextMajor(from:"4.0.0")),
-        .package(url: "https://github.com/slessans/BrightFutures", .branch("bug-swift5pm")),
+        .package(url: "https://github.com/kareman/FootlessParser", .upToNextMajor(from:"0.5.2")),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", .upToNextMajor(from:"6.0.0")),
+        .package(url: "https://github.com/Thomvis/BrightFutures", .upToNextMajor(from:"8.0.0")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/kareman/FootlessParser", .upToNextMajor(from:"0.5.1")),
         .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", .upToNextMajor(from:"4.0.0")),
-        .package(url: "https://github.com/Thomvis/BrightFutures", .upToNextMajor(from:"7.0.0")),
+        .package(url: "https://github.com/slessans/BrightFutures", .branch("bug-swift5pm")),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/SwiftSparql/Classes/Sugar.swift
+++ b/SwiftSparql/Classes/Sugar.swift
@@ -39,7 +39,7 @@ public extension OrderCondition {
     }
 }
 
-public extension WhereClause {
+extension WhereClause {
     public init(patterns: [GroupGraphPatternSubType]) {
         self.init(pattern: .groupGraphPatternSub(.init(patterns: patterns)))
     }

--- a/SwiftSparql/Classes/SyntaxPublicInit.swift
+++ b/SwiftSparql/Classes/SyntaxPublicInit.swift
@@ -1,5 +1,5 @@
 
-public extension Query {
+extension Query {
     // generic select query
     public init(prologues: [Prologue] = [], select: SelectQuery) {
         self.prologues = prologues
@@ -8,7 +8,7 @@ public extension Query {
     }
 }
 
-public extension SelectQuery {
+extension SelectQuery {
     public init(
         option: SelectClause.Option? = nil,
         capture: SelectClause.Capture = .all,
@@ -26,7 +26,7 @@ public extension SelectQuery {
     }
 }
 
-public extension SelectClause.Capture {
+extension SelectClause.Capture {
     public static func vars(_ vars: [Var]) -> SelectClause.Capture {
         return .expressions(vars.map {($0, nil)})
     }
@@ -54,7 +54,7 @@ extension Expression: ExpressibleByStringLiteral {
     }
 }
 
-public extension ValueLogical {
+extension ValueLogical {
     public init(_ v: Var) {
         self = .numeric(.init(v))
     }
@@ -81,13 +81,13 @@ public func > (lhs: NumericExpression, rhs: Var) -> ValueLogical { return .gt(lh
 public func <= (lhs: NumericExpression, rhs: Var) -> ValueLogical { return .lte(lhs, NumericExpression(rhs)) }
 public func >= (lhs: NumericExpression, rhs: Var) -> ValueLogical { return .gte(lhs, NumericExpression(rhs)) }
 
-public extension Constraint {
+extension Constraint {
     public static func logical(_ v: ValueLogical) -> Constraint {
         return .brackettedExpression(.init(v))
     }
 }
 
-public extension NumericExpression {
+extension NumericExpression {
     public init(_ v: Var) {
         self = .single((.simple(.var(v)), []))
     }
@@ -104,14 +104,14 @@ extension LimitOffsetClauses: ExpressibleByIntegerLiteral {
     }
 }
 
-public extension WhereClause {
+extension WhereClause {
     public init(first: TriplesBlock?,
                 successors: [(GraphPatternNotTriples, TriplesBlock?)]) {
         self.init(pattern: .groupGraphPatternSub(.init(first: first, successors: successors)))
     }
 }
 
-public extension TriplesBlock {
+extension TriplesBlock {
     public init(
         triplesSameSubjectPath: TriplesSameSubjectPath,
         triplesBlock: TriplesBlock?) {

--- a/SwiftSparql/Classes/Turtle.swift
+++ b/SwiftSparql/Classes/Turtle.swift
@@ -640,7 +640,7 @@ extension PNameNS {
 
 // MARK: - convenience methods
 
-public extension TurtleDoc {
+extension TurtleDoc {
     public var triples: [Triple] {
         return statements.compactMap {
             switch $0 {

--- a/SwiftSparql/Classes/verbgen/imasparql.swift
+++ b/SwiftSparql/Classes/verbgen/imasparql.swift
@@ -249,36 +249,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("owns"), value: [.var(v)])
     }
     
-    /// memberOf: An Organization (or ProgramMembership) to which this Person or Organization belongs.
-    func schemaMemberOf(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("memberOf"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// memberOf: An Organization (or ProgramMembership) to which this Person or Organization belongs.
-    func schemaMemberOf(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("memberOf"), value: [.var(v)])
-    }
-    
-    /// familyName: Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
-    func schemaFamilyName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("familyName"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// familyName: Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
-    func schemaFamilyName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("familyName"), value: [.var(v)])
-    }
-    
-    /// 所属コンテンツ: 所属コンテンツを表すプロパティ
-    func imasTitle(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Title"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 所属コンテンツ: 所属コンテンツを表すプロパティ
-    func imasTitle(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Title"), value: [.var(v)])
-    }
-    
     /// 姓よみがな: 姓のよみがなを表すプロパティ
     func imasFamilyNameKana(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("familyNameKana"), value: [.varOrTerm(.term(v))])
@@ -289,164 +259,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("familyNameKana"), value: [.var(v)])
     }
     
-    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
-    func imasType(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Type"), value: [.varOrTerm(.term(v))])
+    /// memberOf: An Organization (or ProgramMembership) to which this Person or Organization belongs.
+    func schemaMemberOf(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("memberOf"), value: [.varOrTerm(.term(v))])
     }
     
-    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
-    func imasType(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Type"), value: [.var(v)])
-    }
-    
-    /// 趣味: 趣味を表すプロパティ
-    func imasHobby(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hobby"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 趣味: 趣味を表すプロパティ
-    func imasHobby(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hobby"), value: [.var(v)])
-    }
-    
-    /// 担当声優: 担当声優を表すプロパティ
-    func imasCv(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("cv"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 担当声優: 担当声優を表すプロパティ
-    func imasCv(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("cv"), value: [.var(v)])
-    }
-    
-    /// 胸囲: 胸囲を表すプロパティ
-    func imasBust(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Bust"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 胸囲: 胸囲を表すプロパティ
-    func imasBust(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Bust"), value: [.var(v)])
-    }
-    
-    /// 臀囲: 臀囲(尻囲)を表すプロパティ
-    func imasHip(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hip"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 臀囲: 臀囲(尻囲)を表すプロパティ
-    func imasHip(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hip"), value: [.var(v)])
-    }
-    
-    /// birthDate: Date of birth.
-    func schemaBirthDate(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthDate"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// birthDate: Date of birth.
-    func schemaBirthDate(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthDate"), value: [.var(v)])
-    }
-    
-    /// height: The height of the item.
-    func schemaHeight(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("height"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// height: The height of the item.
-    func schemaHeight(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("height"), value: [.var(v)])
-    }
-    
-    /// age: The age in years of some agent.
-    func foafAge(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: FoafSchema.verb("age"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// age: The age in years of some agent.
-    func foafAge(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: FoafSchema.verb("age"), value: [.var(v)])
-    }
-    
-    /// イメージカラー: イメージカラーを表すプロパティ
-    func imasColor(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Color"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// イメージカラー: イメージカラーを表すプロパティ
-    func imasColor(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Color"), value: [.var(v)])
-    }
-    
-    /// 血液型: 血液型を表すプロパティ
-    func imasBloodType(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("BloodType"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 血液型: 血液型を表すプロパティ
-    func imasBloodType(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("BloodType"), value: [.var(v)])
-    }
-    
-    /// 腹囲: 腹囲を表すプロパティ
-    func imasWaist(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Waist"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 腹囲: 腹囲を表すプロパティ
-    func imasWaist(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Waist"), value: [.var(v)])
-    }
-    
-    /// 聞き手: 聞き手を表すプロパティ
-    func imasHandedness(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Handedness"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 聞き手: 聞き手を表すプロパティ
-    func imasHandedness(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Handedness"), value: [.var(v)])
-    }
-    
-    /// birthPlace: The place where the person was born.
-    func schemaBirthPlace(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// birthPlace: The place where the person was born.
-    func schemaBirthPlace(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.var(v)])
-    }
-    
-    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
-    func schemaGivenName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("givenName"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
-    func schemaGivenName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("givenName"), value: [.var(v)])
-    }
-    
-    /// 星座: 星座を表すプロパティ
-    func imasConstellation(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Constellation"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 星座: 星座を表すプロパティ
-    func imasConstellation(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Constellation"), value: [.var(v)])
-    }
-    
-    /// 
-    func rdfType(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: RdfSchema.verb("type"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 
-    func rdfType(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: RdfSchema.verb("type"), value: [.var(v)])
+    /// memberOf: An Organization (or ProgramMembership) to which this Person or Organization belongs.
+    func schemaMemberOf(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("memberOf"), value: [.var(v)])
     }
     
     /// weight: The weight of the product or person.
@@ -459,14 +279,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("weight"), value: [.var(v)])
     }
     
-    /// 名前よみがな: 名前のよみがなを表すプロパティ
-    func imasNameKana(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("nameKana"), value: [.varOrTerm(.term(v))])
+    /// 名よみがな: 名のよみがなを表すプロパティ
+    func imasGivenNameKana(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 名前よみがな: 名前のよみがなを表すプロパティ
-    func imasNameKana(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("nameKana"), value: [.var(v)])
+    /// 名よみがな: 名のよみがなを表すプロパティ
+    func imasGivenNameKana(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.var(v)])
     }
     
     /// name: The name of the item.
@@ -479,6 +299,156 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("name"), value: [.var(v)])
     }
     
+    /// height: The height of the item.
+    func schemaHeight(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("height"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// height: The height of the item.
+    func schemaHeight(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("height"), value: [.var(v)])
+    }
+    
+    /// 血液型: 血液型を表すプロパティ
+    func imasBloodType(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("BloodType"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 血液型: 血液型を表すプロパティ
+    func imasBloodType(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("BloodType"), value: [.var(v)])
+    }
+    
+    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
+    func imasType(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Type"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
+    func imasType(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Type"), value: [.var(v)])
+    }
+    
+    /// age: The age in years of some agent.
+    func foafAge(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: FoafSchema.verb("age"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// age: The age in years of some agent.
+    func foafAge(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: FoafSchema.verb("age"), value: [.var(v)])
+    }
+    
+    /// 名前よみがな: 名前のよみがなを表すプロパティ
+    func imasNameKana(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("nameKana"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 名前よみがな: 名前のよみがなを表すプロパティ
+    func imasNameKana(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("nameKana"), value: [.var(v)])
+    }
+    
+    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
+    func schemaGivenName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("givenName"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
+    func schemaGivenName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("givenName"), value: [.var(v)])
+    }
+    
+    /// 胸囲: 胸囲を表すプロパティ
+    func imasBust(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Bust"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 胸囲: 胸囲を表すプロパティ
+    func imasBust(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Bust"), value: [.var(v)])
+    }
+    
+    /// 所属コンテンツ: 所属コンテンツを表すプロパティ
+    func imasTitle(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Title"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 所属コンテンツ: 所属コンテンツを表すプロパティ
+    func imasTitle(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Title"), value: [.var(v)])
+    }
+    
+    /// birthPlace: The place where the person was born.
+    func schemaBirthPlace(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// birthPlace: The place where the person was born.
+    func schemaBirthPlace(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.var(v)])
+    }
+    
+    /// 星座: 星座を表すプロパティ
+    func imasConstellation(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Constellation"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 星座: 星座を表すプロパティ
+    func imasConstellation(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Constellation"), value: [.var(v)])
+    }
+    
+    /// birthDate: Date of birth.
+    func schemaBirthDate(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthDate"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// birthDate: Date of birth.
+    func schemaBirthDate(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthDate"), value: [.var(v)])
+    }
+    
+    /// familyName: Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
+    func schemaFamilyName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("familyName"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// familyName: Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
+    func schemaFamilyName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("familyName"), value: [.var(v)])
+    }
+    
+    /// 趣味: 趣味を表すプロパティ
+    func imasHobby(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hobby"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 趣味: 趣味を表すプロパティ
+    func imasHobby(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hobby"), value: [.var(v)])
+    }
+    
+    /// 
+    func rdfType(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: RdfSchema.verb("type"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 
+    func rdfType(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: RdfSchema.verb("type"), value: [.var(v)])
+    }
+    
+    /// 利き手: 利き手を表すプロパティ
+    func imasHandedness(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Handedness"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 利き手: 利き手を表すプロパティ
+    func imasHandedness(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Handedness"), value: [.var(v)])
+    }
+    
     /// gender: Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender.
     func schemaGender(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: SchemaSchema.verb("gender"), value: [.varOrTerm(.term(v))])
@@ -489,24 +459,44 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("gender"), value: [.var(v)])
     }
     
-    /// 名よみがな: 名のよみがなを表すプロパティ
-    func imasGivenNameKana(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.varOrTerm(.term(v))])
+    /// 臀囲: 臀囲(尻囲)を表すプロパティ
+    func imasHip(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hip"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 名よみがな: 名のよみがなを表すプロパティ
-    func imasGivenNameKana(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.var(v)])
+    /// 臀囲: 臀囲(尻囲)を表すプロパティ
+    func imasHip(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hip"), value: [.var(v)])
     }
     
-    /// 属性: 属性(Vo,Da,Vi)を表すプロパティ
-    func imasAttribute(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Attribute"), value: [.varOrTerm(.term(v))])
+    /// 腹囲: 腹囲を表すプロパティ
+    func imasWaist(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Waist"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 属性: 属性(Vo,Da,Vi)を表すプロパティ
-    func imasAttribute(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Attribute"), value: [.var(v)])
+    /// 腹囲: 腹囲を表すプロパティ
+    func imasWaist(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Waist"), value: [.var(v)])
+    }
+    
+    /// 担当声優: 担当声優を表すプロパティ
+    func imasCv(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("cv"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 担当声優: 担当声優を表すプロパティ
+    func imasCv(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("cv"), value: [.var(v)])
+    }
+    
+    /// イメージカラー: イメージカラーを表すプロパティ
+    func imasColor(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Color"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// イメージカラー: イメージカラーを表すプロパティ
+    func imasColor(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Color"), value: [.var(v)])
     }
     
     /// 特技: 特技を表すプロパティ
@@ -519,6 +509,26 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("Talent"), value: [.var(v)])
     }
     
+    /// 通称よみがな: 通称のよみがなを表すプロパティ
+    func imasAlternateNameKana(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 通称よみがな: 通称のよみがなを表すプロパティ
+    func imasAlternateNameKana(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.var(v)])
+    }
+    
+    /// alternateName: An alias for the item.
+    func schemaAlternateName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("alternateName"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// alternateName: An alias for the item.
+    func schemaAlternateName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
+    }
+    
     /// 好きなもの: 好きなものを表すプロパティ
     func imasFavorite(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Favorite"), value: [.varOrTerm(.term(v))])
@@ -527,26 +537,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// 好きなもの: 好きなものを表すプロパティ
     func imasFavorite(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Favorite"), value: [.var(v)])
-    }
-    
-    /// 区分: 区分(Princess・Fairy・Angel)を表すプロパティ
-    func imasDivision(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Division"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 区分: 区分(Princess・Fairy・Angel)を表すプロパティ
-    func imasDivision(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Division"), value: [.var(v)])
-    }
-    
-    /// description: A description of the item.
-    func schemaDescription(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("description"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// description: A description of the item.
-    func schemaDescription(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("description"), value: [.var(v)])
     }
     
     /// カテゴリ: カテゴリ(メンタル・フィジカル・インテリ)を表すプロパティ
@@ -569,24 +559,34 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("ShoeSize"), value: [.var(v)])
     }
     
-    /// 通称よみがな: 通称のよみがなを表すプロパティ
-    func imasAlternateNameKana(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.varOrTerm(.term(v))])
+    /// 属性: 属性(Vo,Da,Vi)を表すプロパティ
+    func imasAttribute(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Attribute"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 通称よみがな: 通称のよみがなを表すプロパティ
-    func imasAlternateNameKana(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.var(v)])
+    /// 属性: 属性(Vo,Da,Vi)を表すプロパティ
+    func imasAttribute(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Attribute"), value: [.var(v)])
     }
     
-    /// alternateName: An alias for the item.
-    func schemaAlternateName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("alternateName"), value: [.varOrTerm(.term(v))])
+    /// 区分: 区分(Princess・Fairy・Angel)を表すプロパティ
+    func imasDivision(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Division"), value: [.varOrTerm(.term(v))])
     }
     
-    /// alternateName: An alias for the item.
-    func schemaAlternateName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
+    /// 区分: 区分(Princess・Fairy・Angel)を表すプロパティ
+    func imasDivision(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Division"), value: [.var(v)])
+    }
+    
+    /// description: A description of the item.
+    func schemaDescription(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("description"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// description: A description of the item.
+    func schemaDescription(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("description"), value: [.var(v)])
     }
 }
 
@@ -811,12 +811,12 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("Bust"), value: [.var(v)])
     }
     
-    /// 聞き手: 聞き手を表すプロパティ
+    /// 利き手: 利き手を表すプロパティ
     func imasHandedness(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Handedness"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 聞き手: 聞き手を表すプロパティ
+    /// 利き手: 利き手を表すプロパティ
     func imasHandedness(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Handedness"), value: [.var(v)])
     }

--- a/SwiftSparql/Classes/verbgen/imasparql.swift
+++ b/SwiftSparql/Classes/verbgen/imasparql.swift
@@ -239,24 +239,24 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
 }
 
 public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, State.RDFType == ImasIdol {
-    /// owns: Products owned by the organization or person.
-    func schemaOwns(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("owns"), value: [.varOrTerm(.term(v))])
+    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
+    func schemaGivenName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("givenName"), value: [.varOrTerm(.term(v))])
     }
     
-    /// owns: Products owned by the organization or person.
-    func schemaOwns(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("owns"), value: [.var(v)])
+    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
+    func schemaGivenName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("givenName"), value: [.var(v)])
     }
     
-    /// 姓よみがな: 姓のよみがなを表すプロパティ
-    func imasFamilyNameKana(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("familyNameKana"), value: [.varOrTerm(.term(v))])
+    /// birthDate: Date of birth.
+    func schemaBirthDate(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthDate"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 姓よみがな: 姓のよみがなを表すプロパティ
-    func imasFamilyNameKana(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("familyNameKana"), value: [.var(v)])
+    /// birthDate: Date of birth.
+    func schemaBirthDate(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthDate"), value: [.var(v)])
     }
     
     /// memberOf: An Organization (or ProgramMembership) to which this Person or Organization belongs.
@@ -269,24 +269,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("memberOf"), value: [.var(v)])
     }
     
-    /// weight: The weight of the product or person.
-    func schemaWeight(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("weight"), value: [.varOrTerm(.term(v))])
+    /// owns: Products owned by the organization or person.
+    func schemaOwns(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("owns"), value: [.varOrTerm(.term(v))])
     }
     
-    /// weight: The weight of the product or person.
-    func schemaWeight(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("weight"), value: [.var(v)])
-    }
-    
-    /// 名よみがな: 名のよみがなを表すプロパティ
-    func imasGivenNameKana(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 名よみがな: 名のよみがなを表すプロパティ
-    func imasGivenNameKana(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.var(v)])
+    /// owns: Products owned by the organization or person.
+    func schemaOwns(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("owns"), value: [.var(v)])
     }
     
     /// name: The name of the item.
@@ -299,44 +289,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("name"), value: [.var(v)])
     }
     
-    /// height: The height of the item.
-    func schemaHeight(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("height"), value: [.varOrTerm(.term(v))])
+    /// 姓よみがな: 姓のよみがなを表すプロパティ
+    func imasFamilyNameKana(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("familyNameKana"), value: [.varOrTerm(.term(v))])
     }
     
-    /// height: The height of the item.
-    func schemaHeight(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("height"), value: [.var(v)])
-    }
-    
-    /// 血液型: 血液型を表すプロパティ
-    func imasBloodType(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("BloodType"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 血液型: 血液型を表すプロパティ
-    func imasBloodType(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("BloodType"), value: [.var(v)])
-    }
-    
-    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
-    func imasType(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Type"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
-    func imasType(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Type"), value: [.var(v)])
-    }
-    
-    /// age: The age in years of some agent.
-    func foafAge(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: FoafSchema.verb("age"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// age: The age in years of some agent.
-    func foafAge(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: FoafSchema.verb("age"), value: [.var(v)])
+    /// 姓よみがな: 姓のよみがなを表すプロパティ
+    func imasFamilyNameKana(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("familyNameKana"), value: [.var(v)])
     }
     
     /// 名前よみがな: 名前のよみがなを表すプロパティ
@@ -349,24 +309,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("nameKana"), value: [.var(v)])
     }
     
-    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
-    func schemaGivenName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("givenName"), value: [.varOrTerm(.term(v))])
+    /// height: The height of the item.
+    func schemaHeight(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("height"), value: [.varOrTerm(.term(v))])
     }
     
-    /// givenName: Given name. In the U.S., the first name of a Person. This can be used along with familyName instead of the name property.
-    func schemaGivenName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("givenName"), value: [.var(v)])
-    }
-    
-    /// 胸囲: 胸囲を表すプロパティ
-    func imasBust(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Bust"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 胸囲: 胸囲を表すプロパティ
-    func imasBust(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Bust"), value: [.var(v)])
+    /// height: The height of the item.
+    func schemaHeight(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("height"), value: [.var(v)])
     }
     
     /// 所属コンテンツ: 所属コンテンツを表すプロパティ
@@ -379,34 +329,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("Title"), value: [.var(v)])
     }
     
-    /// birthPlace: The place where the person was born.
-    func schemaBirthPlace(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.varOrTerm(.term(v))])
+    /// 名よみがな: 名のよみがなを表すプロパティ
+    func imasGivenNameKana(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.varOrTerm(.term(v))])
     }
     
-    /// birthPlace: The place where the person was born.
-    func schemaBirthPlace(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.var(v)])
-    }
-    
-    /// 星座: 星座を表すプロパティ
-    func imasConstellation(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Constellation"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 星座: 星座を表すプロパティ
-    func imasConstellation(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Constellation"), value: [.var(v)])
-    }
-    
-    /// birthDate: Date of birth.
-    func schemaBirthDate(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthDate"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// birthDate: Date of birth.
-    func schemaBirthDate(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthDate"), value: [.var(v)])
+    /// 名よみがな: 名のよみがなを表すプロパティ
+    func imasGivenNameKana(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("givenNameKana"), value: [.var(v)])
     }
     
     /// familyName: Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
@@ -429,24 +359,14 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: ImasSchema.verb("Hobby"), value: [.var(v)])
     }
     
-    /// 
-    func rdfType(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: RdfSchema.verb("type"), value: [.varOrTerm(.term(v))])
+    /// age: The age in years of some agent.
+    func foafAge(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: FoafSchema.verb("age"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 
-    func rdfType(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: RdfSchema.verb("type"), value: [.var(v)])
-    }
-    
-    /// 利き手: 利き手を表すプロパティ
-    func imasHandedness(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Handedness"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 利き手: 利き手を表すプロパティ
-    func imasHandedness(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Handedness"), value: [.var(v)])
+    /// age: The age in years of some agent.
+    func foafAge(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: FoafSchema.verb("age"), value: [.var(v)])
     }
     
     /// gender: Gender of the person. While http://schema.org/Male and http://schema.org/Female may be used, text strings are also acceptable for people who do not identify as a binary gender.
@@ -459,14 +379,64 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("gender"), value: [.var(v)])
     }
     
-    /// 臀囲: 臀囲(尻囲)を表すプロパティ
-    func imasHip(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hip"), value: [.varOrTerm(.term(v))])
+    /// weight: The weight of the product or person.
+    func schemaWeight(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("weight"), value: [.varOrTerm(.term(v))])
     }
     
-    /// 臀囲: 臀囲(尻囲)を表すプロパティ
-    func imasHip(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hip"), value: [.var(v)])
+    /// weight: The weight of the product or person.
+    func schemaWeight(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("weight"), value: [.var(v)])
+    }
+    
+    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
+    func imasType(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Type"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
+    func imasType(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Type"), value: [.var(v)])
+    }
+    
+    /// 
+    func rdfsLabel(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: RdfsSchema.verb("label"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 
+    func rdfsLabel(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: RdfsSchema.verb("label"), value: [.var(v)])
+    }
+    
+    /// 血液型: 血液型を表すプロパティ
+    func imasBloodType(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("BloodType"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 血液型: 血液型を表すプロパティ
+    func imasBloodType(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("BloodType"), value: [.var(v)])
+    }
+    
+    /// birthPlace: The place where the person was born.
+    func schemaBirthPlace(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// birthPlace: The place where the person was born.
+    func schemaBirthPlace(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.var(v)])
+    }
+    
+    /// 利き手: 利き手を表すプロパティ
+    func imasHandedness(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Handedness"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 利き手: 利き手を表すプロパティ
+    func imasHandedness(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Handedness"), value: [.var(v)])
     }
     
     /// 腹囲: 腹囲を表すプロパティ
@@ -477,6 +447,46 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// 腹囲: 腹囲を表すプロパティ
     func imasWaist(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Waist"), value: [.var(v)])
+    }
+    
+    /// 
+    func rdfType(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: RdfSchema.verb("type"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 
+    func rdfType(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: RdfSchema.verb("type"), value: [.var(v)])
+    }
+    
+    /// 臀囲: 臀囲(尻囲)を表すプロパティ
+    func imasHip(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hip"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 臀囲: 臀囲(尻囲)を表すプロパティ
+    func imasHip(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hip"), value: [.var(v)])
+    }
+    
+    /// 胸囲: 胸囲を表すプロパティ
+    func imasBust(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Bust"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 胸囲: 胸囲を表すプロパティ
+    func imasBust(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Bust"), value: [.var(v)])
+    }
+    
+    /// 星座: 星座を表すプロパティ
+    func imasConstellation(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Constellation"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 星座: 星座を表すプロパティ
+    func imasConstellation(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Constellation"), value: [.var(v)])
     }
     
     /// 担当声優: 担当声優を表すプロパティ
@@ -507,26 +517,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// 特技: 特技を表すプロパティ
     func imasTalent(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Talent"), value: [.var(v)])
-    }
-    
-    /// 通称よみがな: 通称のよみがなを表すプロパティ
-    func imasAlternateNameKana(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 通称よみがな: 通称のよみがなを表すプロパティ
-    func imasAlternateNameKana(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.var(v)])
-    }
-    
-    /// alternateName: An alias for the item.
-    func schemaAlternateName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("alternateName"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// alternateName: An alias for the item.
-    func schemaAlternateName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
     }
     
     /// 好きなもの: 好きなものを表すプロパティ
@@ -588,6 +578,26 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     func schemaDescription(is v: Var) -> TripleBuilder<State> {
         return appended(verb: SchemaSchema.verb("description"), value: [.var(v)])
     }
+    
+    /// 通称よみがな: 通称のよみがなを表すプロパティ
+    func imasAlternateNameKana(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 通称よみがな: 通称のよみがなを表すプロパティ
+    func imasAlternateNameKana(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("alternateNameKana"), value: [.var(v)])
+    }
+    
+    /// alternateName: An alias for the item.
+    func schemaAlternateName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("alternateName"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// alternateName: An alias for the item.
+    func schemaAlternateName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
+    }
 }
 
 public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, State.RDFType == ImasStaff {
@@ -611,6 +621,16 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: FoafSchema.verb("age"), value: [.var(v)])
     }
     
+    /// name: The name of the item.
+    func schemaName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("name"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// name: The name of the item.
+    func schemaName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("name"), value: [.var(v)])
+    }
+    
     /// 名よみがな: 名のよみがなを表すプロパティ
     func imasGivenNameKana(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("givenNameKana"), value: [.varOrTerm(.term(v))])
@@ -629,6 +649,16 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// familyName: Family name. In the U.S., the last name of an Person. This can be used along with givenName instead of the name property.
     func schemaFamilyName(is v: Var) -> TripleBuilder<State> {
         return appended(verb: SchemaSchema.verb("familyName"), value: [.var(v)])
+    }
+    
+    /// 
+    func rdfsLabel(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: RdfsSchema.verb("label"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 
+    func rdfsLabel(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: RdfsSchema.verb("label"), value: [.var(v)])
     }
     
     /// 名前よみがな: 名前のよみがなを表すプロパティ
@@ -681,16 +711,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("position"), value: [.var(v)])
     }
     
-    /// name: The name of the item.
-    func schemaName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("name"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// name: The name of the item.
-    func schemaName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("name"), value: [.var(v)])
-    }
-    
     /// memberOf: An Organization (or ProgramMembership) to which this Person or Organization belongs.
     func schemaMemberOf(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: SchemaSchema.verb("memberOf"), value: [.varOrTerm(.term(v))])
@@ -711,16 +731,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("gender"), value: [.var(v)])
     }
     
-    /// weight: The weight of the product or person.
-    func schemaWeight(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("weight"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// weight: The weight of the product or person.
-    func schemaWeight(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("weight"), value: [.var(v)])
-    }
-    
     /// 血液型: 血液型を表すプロパティ
     func imasBloodType(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("BloodType"), value: [.varOrTerm(.term(v))])
@@ -729,56 +739,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// 血液型: 血液型を表すプロパティ
     func imasBloodType(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("BloodType"), value: [.var(v)])
-    }
-    
-    /// height: The height of the item.
-    func schemaHeight(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("height"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// height: The height of the item.
-    func schemaHeight(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("height"), value: [.var(v)])
-    }
-    
-    /// 星座: 星座を表すプロパティ
-    func imasConstellation(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Constellation"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 星座: 星座を表すプロパティ
-    func imasConstellation(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Constellation"), value: [.var(v)])
-    }
-    
-    /// birthDate: Date of birth.
-    func schemaBirthDate(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthDate"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// birthDate: Date of birth.
-    func schemaBirthDate(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthDate"), value: [.var(v)])
-    }
-    
-    /// 趣味: 趣味を表すプロパティ
-    func imasHobby(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hobby"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 趣味: 趣味を表すプロパティ
-    func imasHobby(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Hobby"), value: [.var(v)])
-    }
-    
-    /// birthPlace: The place where the person was born.
-    func schemaBirthPlace(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// birthPlace: The place where the person was born.
-    func schemaBirthPlace(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.var(v)])
     }
     
     /// alternateName: An alias for the item.
@@ -791,6 +751,36 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
     }
     
+    /// weight: The weight of the product or person.
+    func schemaWeight(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("weight"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// weight: The weight of the product or person.
+    func schemaWeight(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("weight"), value: [.var(v)])
+    }
+    
+    /// birthPlace: The place where the person was born.
+    func schemaBirthPlace(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// birthPlace: The place where the person was born.
+    func schemaBirthPlace(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthPlace"), value: [.var(v)])
+    }
+    
+    /// height: The height of the item.
+    func schemaHeight(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("height"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// height: The height of the item.
+    func schemaHeight(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("height"), value: [.var(v)])
+    }
+    
     /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
     func imasType(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Type"), value: [.varOrTerm(.term(v))])
@@ -799,6 +789,16 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// タイプ: タイプ(Cu,Co,Pa)を表すプロパティ
     func imasType(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Type"), value: [.var(v)])
+    }
+    
+    /// birthDate: Date of birth.
+    func schemaBirthDate(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthDate"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// birthDate: Date of birth.
+    func schemaBirthDate(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("birthDate"), value: [.var(v)])
     }
     
     /// 胸囲: 胸囲を表すプロパティ
@@ -819,6 +819,26 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// 利き手: 利き手を表すプロパティ
     func imasHandedness(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Handedness"), value: [.var(v)])
+    }
+    
+    /// 趣味: 趣味を表すプロパティ
+    func imasHobby(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hobby"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 趣味: 趣味を表すプロパティ
+    func imasHobby(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Hobby"), value: [.var(v)])
+    }
+    
+    /// 星座: 星座を表すプロパティ
+    func imasConstellation(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Constellation"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 星座: 星座を表すプロパティ
+    func imasConstellation(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Constellation"), value: [.var(v)])
     }
     
     /// 腹囲: 腹囲を表すプロパティ
@@ -913,16 +933,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
         return appended(verb: RdfSchema.verb("type"), value: [.var(v)])
     }
     
-    /// alternateName: An alias for the item.
-    func schemaAlternateName(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("alternateName"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// alternateName: An alias for the item.
-    func schemaAlternateName(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
-    }
-    
     /// イメージカラー: イメージカラーを表すプロパティ
     func imasColor(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Color"), value: [.varOrTerm(.term(v))])
@@ -931,6 +941,16 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// イメージカラー: イメージカラーを表すプロパティ
     func imasColor(is v: Var) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("Color"), value: [.var(v)])
+    }
+    
+    /// alternateName: An alias for the item.
+    func schemaAlternateName(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("alternateName"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// alternateName: An alias for the item.
+    func schemaAlternateName(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: SchemaSchema.verb("alternateName"), value: [.var(v)])
     }
     
     /// description: A description of the item.
@@ -1167,16 +1187,6 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
 }
 
 public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, State.RDFType == ImasScriptText {
-    /// 出どころ: 出どころを表すプロパティ
-    func imasSource(is v: GraphTerm) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Source"), value: [.varOrTerm(.term(v))])
-    }
-    
-    /// 出どころ: 出どころを表すプロパティ
-    func imasSource(is v: Var) -> TripleBuilder<State> {
-        return appended(verb: ImasSchema.verb("Source"), value: [.var(v)])
-    }
-    
     /// 発言者表記: 発言者表記を表すプロパティ
     func imasSpeakerLabel(is v: GraphTerm) -> TripleBuilder<State> {
         return appended(verb: ImasSchema.verb("SpeakerLabel"), value: [.varOrTerm(.term(v))])
@@ -1215,6 +1225,16 @@ public extension TripleBuilder where State: TripleBuilderStateRDFTypeBoundType, 
     /// 
     func rdfType(is v: Var) -> TripleBuilder<State> {
         return appended(verb: RdfSchema.verb("type"), value: [.var(v)])
+    }
+    
+    /// 出どころ: 出どころを表すプロパティ
+    func imasSource(is v: GraphTerm) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Source"), value: [.varOrTerm(.term(v))])
+    }
+    
+    /// 出どころ: 出どころを表すプロパティ
+    func imasSource(is v: Var) -> TripleBuilder<State> {
+        return appended(verb: ImasSchema.verb("Source"), value: [.var(v)])
     }
 }
 

--- a/verbgen/TurtleFetcher.swift
+++ b/verbgen/TurtleFetcher.swift
@@ -1,7 +1,6 @@
 import Foundation
 import SwiftSparql
 import ReactiveSwift
-import enum Result.NoError
 
 struct TurtleFetcher {
     var urls: [URL]
@@ -14,7 +13,7 @@ struct TurtleFetcher {
         SignalProducer(urls)
             .on(value: {print("fetching \($0)")})
             .flatMap(.concat) { url in
-                SignalProducer<Data, NoError> { observer, lifetime in
+                SignalProducer<Data, Never> { observer, lifetime in
                     URLSession.shared.dataTask(with: url) { data, response, error in
                         guard let data = data else { fatalError(String(describing: error)) }
                         observer.send(value: data)

--- a/verbgen/VerbGen.swift
+++ b/verbgen/VerbGen.swift
@@ -1,7 +1,6 @@
 import SwiftSparql
 import struct Foundation.URL
 import ReactiveSwift
-import enum Result.NoError
 
 enum _RdfSchema: SwiftSparql.IRIBaseProvider {
     public static var base: IRIRef {return IRIRef(value: "http://www.w3.org/1999/02/22-rdf-syntax-ns#")}
@@ -50,7 +49,7 @@ struct VerbGen {
         
         SignalProducer(classes)
             .flatMap(.concat) { subjectDescription in
-                SignalProducer<[VerbQuery.Response], NoError> { observer, lifetime in
+                SignalProducer<[VerbQuery.Response], Never> { observer, lifetime in
                     VerbQuery(subjectDescription, endpoint: self.endpoint, prologues: prologues).fetch {
                         observer.send(value: $0)
                         observer.sendCompleted()


### PR DESCRIPTION
the remaining warning may be possible swift bug:

```
SwiftSparql/Classes/Turtle.swift:670:22: warning: case is already handled by previous patterns; consider removing it
                case .iri(IRI.prefixedName(.ln((PNameNS(value: "rdfs"), "comment")))):
                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```